### PR TITLE
Remove duplicate textarea branch and stray debug output in hosting config template

### DIFF
--- a/modules/servers/panelalpha/resources/templates/components/product/product-plan-settings.tpl
+++ b/modules/servers/panelalpha/resources/templates/components/product/product-plan-settings.tpl
@@ -256,8 +256,6 @@
                            data-field-name="{$config['name']}"
                            id="{$config['name']}_config_field"
                            value="{if $config['value'] == '1'}1{else}0{/if}"/>
-                  {elseif $config['type'] === 'textarea'}
-                    <span>asdasdas</span>
                   {/if}
               </div>
             {/foreach}


### PR DESCRIPTION
## Description

###Overview
This PR cleans up the hosting account configuration template by removing an unreachable duplicate `textarea` conditional and deleting a stray debug string that could be rendered in the UI.

###Changes
- Removed a duplicated `{elseif $config['type'] === 'textarea'}` branch that was redundant/unreachable.
- Removed the unintended `asdasdas` output from the template.

###Why
- Prevents accidental debug text from appearing in the admin UI.
- Improves readability and maintainability of the template logic by keeping the conditional branches single and unambiguous.

###Notes
- This is a template-only change; no PHP logic has been modified.
- Intended to be behaviour-preserving, aside from removing the stray debug output.