### PR TITLE
fix(whmcs): resolve server location from checkout city labels

### DIFF
--- a/modules/servers/panelalpha/lib/Helper.php
+++ b/modules/servers/panelalpha/lib/Helper.php
@@ -14,6 +14,46 @@ class Helper
         'sites',
     ];
 
+    private static array $hostingAccountConfigExcludedKeys = [
+        'Service ID',
+        'User ID',
+        'Instance Name',
+        'server_location',
+        'sites',
+        'location',
+        'Location',
+    ];
+
+    /**
+     * Maps checkout location labels to hostname geo tokens (e.g. cp11.ams1 → amsterdam).
+     *
+     * @var array<string, list<string>>
+     */
+    private static array $locationLabelKeywords = [
+        'frankfurt' => ['fra'],
+        'amsterdam' => ['ams'],
+        'warsaw' => ['waw'],
+        'los angeles' => ['lax'],
+        'toronto' => ['tor'],
+        'singapore' => ['sgp'],
+        'new york' => ['nyc'],
+        'dubai' => ['dxb'],
+        'sydney' => ['syd'],
+        'sao paulo' => ['bra'],
+        'são paulo' => ['bra'],
+        'zurich' => ['zrh'],
+        'seoul' => ['sel'],
+        'madrid' => ['mad'],
+        'johannesburg' => ['jnb'],
+        'istanbul' => ['ist'],
+        'london' => ['lon', 'lhr'],
+        'dallas' => ['dfw', 'dal'],
+        'mumbai' => ['bom', 'mum'],
+        'tokyo' => ['tyo', 'nrt'],
+        'riyadh' => ['ruh'],
+        'oslo' => ['osl'],
+    ];
+
     /**
      *  @param int $length 
      */
@@ -77,7 +117,10 @@ class Helper
         $value = CustomField::join('tblcustomfieldsvalues', 'tblcustomfieldsvalues.fieldid', '=', 'tblcustomfields.id')
             ->where('tblcustomfieldsvalues.relid', $serviceId)
             ->where('tblcustomfields.type', 'product')
-            ->where('tblcustomfields.fieldname', $fieldName)
+            ->where(function ($query) use ($fieldName) {
+                $query->where('tblcustomfields.fieldname', $fieldName);
+                $query->orWhere('tblcustomfields.fieldname', 'like', $fieldName . '|%');
+            })
             ->value('value');
 
         if (empty($value)) {
@@ -261,10 +304,149 @@ class Helper
         return $instanceLimit ? (int)$instanceLimit : null;
     }
 
-    public static function getServerLocation(array $params): ?int
+    public static function parseServerLocationValue(mixed $value): ?int
     {
-        $serverLocation = $params['configoptions']['server_location'] ?? $params['customfields']['server_location'] ?? null;
-        return $serverLocation ? (int)$serverLocation : null;
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        $parts = explode('|', (string) $value, 2);
+        $candidate = trim($parts[0]);
+
+        if ($candidate === '' || !ctype_digit($candidate)) {
+            return null;
+        }
+
+        $id = (int) $candidate;
+
+        return $id > 0 ? $id : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function getServerLocationCandidateValues(array $params): array
+    {
+        $candidates = [];
+        $sources = [
+            $params['configoptions'] ?? [],
+            $params['customfields'] ?? [],
+        ];
+        $keys = ['server_location', 'location', 'Location'];
+
+        foreach ($sources as $source) {
+            foreach ($keys as $key) {
+                if (!empty($source[$key])) {
+                    $candidates[] = (string) $source[$key];
+                }
+            }
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * @param array<int, array{id?: int, name?: string}> $servers
+     */
+    public static function resolveServerLocationFromLabel(string $label, array $servers): ?int
+    {
+        $label = trim($label);
+        if ($label === '') {
+            return null;
+        }
+
+        $parsed = self::parseServerLocationValue($label);
+        if ($parsed !== null) {
+            return $parsed;
+        }
+
+        $searchTexts = array_unique(array_filter(array_map(
+            static fn (string $text) => strtolower(trim($text)),
+            [$label, ...explode('|', $label)]
+        )));
+
+        foreach ($servers as $server) {
+            $serverId = (int) ($server['id'] ?? 0);
+            $serverName = strtolower((string) ($server['name'] ?? ''));
+            if ($serverId <= 0 || $serverName === '') {
+                continue;
+            }
+
+            foreach ($searchTexts as $text) {
+                if ($text === '') {
+                    continue;
+                }
+
+                if (str_contains($serverName, $text) || str_contains($text, $serverName)) {
+                    return $serverId;
+                }
+            }
+        }
+
+        foreach ($servers as $server) {
+            $serverId = (int) ($server['id'] ?? 0);
+            $serverName = strtolower((string) ($server['name'] ?? ''));
+            if ($serverId <= 0 || $serverName === '') {
+                continue;
+            }
+
+            foreach (self::$locationLabelKeywords as $keyword => $patterns) {
+                $keywordFound = false;
+                foreach ($searchTexts as $text) {
+                    if (str_contains($text, $keyword)) {
+                        $keywordFound = true;
+                        break;
+                    }
+                }
+
+                if (!$keywordFound) {
+                    continue;
+                }
+
+                foreach ($patterns as $pattern) {
+                    if (str_contains($serverName, $pattern)) {
+                        return $serverId;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int, array{id?: int, name?: string}>|null $servers
+     */
+    public static function getServerLocation(array $params, ?array $servers = null): ?int
+    {
+        foreach (self::getServerLocationCandidateValues($params) as $value) {
+            $parsed = self::parseServerLocationValue($value);
+            if ($parsed !== null) {
+                return $parsed;
+            }
+        }
+
+        if ($servers === null) {
+            return null;
+        }
+
+        foreach (self::getServerLocationCandidateValues($params) as $value) {
+            $resolved = self::resolveServerLocationFromLabel($value, $servers);
+            if ($resolved !== null) {
+                return $resolved;
+            }
+        }
+
+        return null;
+    }
+
+    public static function normalizeConfigurableOptionValue(mixed $value): mixed
+    {
+        if (!is_string($value) || !str_contains($value, '|')) {
+            return $value;
+        }
+
+        return explode('|', $value, 2)[0];
     }
 
     public static function getHostingAccountConfig(array $params): array
@@ -280,8 +462,22 @@ class Helper
             ...$params['configoptions'],
         ];
 
-        return array_filter($config, function ($value, $key)  {
-            return !in_array($key, ['Service ID', 'User ID', 'Instance Name', 'server_location', 'sites']);
-        }, ARRAY_FILTER_USE_BOTH);
+        $locationValue = $config['location'] ?? $config['Location'] ?? null;
+        if ($locationValue !== null && self::parseServerLocationValue($locationValue) === null) {
+            $geoAffinity = self::normalizeConfigurableOptionValue($locationValue);
+            if (is_string($geoAffinity) && preg_match('/^[a-z]{3}$/i', $geoAffinity)) {
+                $config['geo_affinity'] = $geoAffinity;
+            }
+        }
+
+        $filtered = array_filter(
+            $config,
+            static function ($value, $key) {
+                return !in_array($key, self::$hostingAccountConfigExcludedKeys, true);
+            },
+            ARRAY_FILTER_USE_BOTH
+        );
+
+        return array_map([self::class, 'normalizeConfigurableOptionValue'], $filtered);
     }
 }

--- a/modules/servers/panelalpha/panelalpha.php
+++ b/modules/servers/panelalpha/panelalpha.php
@@ -318,9 +318,11 @@ function panelalpha_CreateAccount(array $params): string
         }
 
         $planId = $service->product->getPanelAlphaPlanId();
+        $plan = $api->getPlan($planId);
+        $servers = $api->getServers($plan['server_group_id'] ?? null);
 
         $instanceLimit = Helper::getInstanceLimit($params);
-        $serverLocation = Helper::getServerLocation($params);
+        $serverLocation = Helper::getServerLocation($params, $servers);
         $hostingAccountConfig = Helper::getHostingAccountConfig($params);
 
         $panelAlphaService = $api->createService($panelAlphaUser['id'], $planId, $instanceLimit, $serverLocation, $hostingAccountConfig);

--- a/tests/Unit/ServerHelperTest.php
+++ b/tests/Unit/ServerHelperTest.php
@@ -7,6 +7,12 @@ use WHMCS\Module\Server\PanelAlpha\Helper;
 
 class ServerHelperTest extends TestCase
 {
+    private array $sampleServers = [
+        ['id' => 5, 'name' => 'cp4.lax1.ultacp.com'],
+        ['id' => 11, 'name' => 'cp11.ams1.ultacp.com'],
+        ['id' => 15, 'name' => 'cp15.waw1.ultacp.com'],
+    ];
+
     public function testGenerateSecurePassword()
     {
         $length = 16;
@@ -16,5 +22,113 @@ class ServerHelperTest extends TestCase
         $this->assertMatchesRegularExpression('/[A-Z]/', $string);
         $this->assertMatchesRegularExpression('/[0-9]/', $string);
         $this->assertMatchesRegularExpression('/[!@#$%^&*()\\-_=+\\[\\]{};:,.<>?]/', $string);
+    }
+
+    public function testParseServerLocationValue()
+    {
+        $this->assertSame(11, Helper::parseServerLocationValue('11'));
+        $this->assertSame(11, Helper::parseServerLocationValue('11|cp11.ams1.ultacp.com'));
+        $this->assertSame(11, Helper::parseServerLocationValue('11|Amsterdam, NL'));
+        $this->assertNull(Helper::parseServerLocationValue('ams|Amsterdam'));
+        $this->assertNull(Helper::parseServerLocationValue('Amsterdam, NL'));
+        $this->assertNull(Helper::parseServerLocationValue('0'));
+        $this->assertNull(Helper::parseServerLocationValue(''));
+        $this->assertNull(Helper::parseServerLocationValue(null));
+    }
+
+    public function testGetServerLocationFromNumericValues()
+    {
+        $this->assertSame(11, Helper::getServerLocation([
+            'configoptions' => ['server_location' => '11'],
+            'customfields' => [],
+        ]));
+
+        $this->assertSame(11, Helper::getServerLocation([
+            'configoptions' => ['location' => '11|cp11.ams1.ultacp.com'],
+            'customfields' => [],
+        ]));
+
+        $this->assertSame(11, Helper::getServerLocation([
+            'configoptions' => [],
+            'customfields' => ['Location' => '11|Amsterdam, NL'],
+        ]));
+    }
+
+    public function testGetServerLocationPrefersServerLocationOverLocation()
+    {
+        $this->assertSame(5, Helper::getServerLocation([
+            'configoptions' => [
+                'server_location' => '5',
+                'location' => '11|Amsterdam, NL',
+            ],
+            'customfields' => [],
+        ]));
+    }
+
+    public function testGetServerLocationReturnsNullForGeoCodes()
+    {
+        $this->assertNull(Helper::getServerLocation([
+            'configoptions' => ['location' => 'ams|Amsterdam, NL'],
+            'customfields' => [],
+        ]));
+    }
+
+    public function testGetServerLocationResolvesCityLabelWithServers()
+    {
+        $this->assertSame(11, Helper::getServerLocation([
+            'configoptions' => ['server_location' => 'Amsterdam, NL'],
+            'customfields' => [],
+        ], $this->sampleServers));
+
+        $this->assertSame(15, Helper::getServerLocation([
+            'configoptions' => ['location' => 'Warsaw, Poland'],
+            'customfields' => [],
+        ], $this->sampleServers));
+
+        $this->assertSame(5, Helper::getServerLocation([
+            'configoptions' => ['server_location' => 'Los Angeles, USA'],
+            'customfields' => [],
+        ], $this->sampleServers));
+    }
+
+    public function testResolveServerLocationFromLabelMatchesHostname()
+    {
+        $this->assertSame(11, Helper::resolveServerLocationFromLabel('cp11.ams1.ultacp.com', $this->sampleServers));
+        $this->assertSame(11, Helper::resolveServerLocationFromLabel('11|cp11.ams1.ultacp.com', $this->sampleServers));
+    }
+
+    public function testGetHostingAccountConfigExcludesLocationFields()
+    {
+        $config = Helper::getHostingAccountConfig([
+            'configoption11' => false,
+            'customfields' => [
+                'location' => 'Amsterdam, NL',
+                'server_location' => '11',
+            ],
+            'configoptions' => [
+                'sites' => '3',
+                'whm_package' => 'premium|Premium',
+            ],
+        ]);
+
+        $this->assertArrayNotHasKey('location', $config);
+        $this->assertArrayNotHasKey('Location', $config);
+        $this->assertArrayNotHasKey('server_location', $config);
+        $this->assertArrayNotHasKey('sites', $config);
+        $this->assertSame('premium', $config['whm_package']);
+    }
+
+    public function testGetHostingAccountConfigMapsGeoAffinityForWpCloudCodes()
+    {
+        $config = Helper::getHostingAccountConfig([
+            'configoption11' => false,
+            'customfields' => [
+                'location' => 'ams|Amsterdam, NL',
+            ],
+            'configoptions' => [],
+        ]);
+
+        $this->assertArrayNotHasKey('location', $config);
+        $this->assertSame('ams', $config['geo_affinity']);
     }
 }


### PR DESCRIPTION
WHMCS was not passing server_id to PanelAlpha when customers picked a location by city name or via location/Location fields. Parse numeric IDs, map labels to plan servers by hostname geo tokens, and exclude location fields from hosting_account_config.